### PR TITLE
feat(contact): add contact section with phone, email, and GitHub link

### DIFF
--- a/index.html
+++ b/index.html
@@ -83,6 +83,14 @@
       cooking, and exploring beauty and fashion.
     </p>
   </section>
+  <!-- ✅ Contact Section -->
+<section id="contact" class="container">
+  <h2>Contact Me</h2>
+  <p>📱 Phone: +254 92 416 700</p>
+  <p>📧 Email: cynthia.kiio@strathmore.edu</p>
+  <p>🐙 GitHub: <a href="https://github.com/Kaninzz" target="_blank">Kaninzz</a></p>
+</section>
+
 
 </body>
 </html>


### PR DESCRIPTION
This pull request adds a Contact Me section at the bottom of the portfolio. It includes:

- Phone number
- Email address
- A clickable link to my GitHub profile

The section follows consistent styling with the rest of the site and is anchored using the #contact ID for smooth navigation. This implements issue #4 and completes the final section under milestone #1 (Homepage Features).
